### PR TITLE
Add quality score to the end of the sequence name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ test-driver
 testing/reg-test
 testing/reg-test.c
 testing/setup.c
+mktable.dSYM

--- a/output.c
+++ b/output.c
@@ -88,6 +88,8 @@ bool panda_output_fasta(
 	size_t it;
 	panda_writer_append_c(writer, '>');
 	panda_writer_append_id(writer, &sequence->name);
+	panda_writer_append(writer, ";%f", exp(sequence->quality));
+
 	panda_writer_append_c(writer, '\n');
 	for (it = 0; it < sequence->sequence_length; it++) {
 		panda_writer_append_c(writer, panda_nt_to_ascii(sequence->sequence[it].nt));
@@ -103,6 +105,7 @@ bool panda_output_fastq(
 	size_t it;
 	panda_writer_append_c(writer, '@');
 	panda_writer_append_id(writer, &sequence->name);
+	panda_writer_append(writer, ";%f", exp(sequence->quality));
 	panda_writer_append_c(writer, '\n');
 	for (it = 0; it < sequence->sequence_length; it++) {
 		panda_writer_append_c(writer, panda_nt_to_ascii(sequence->sequence[it].nt));


### PR DESCRIPTION
Added the quality score probability to the end of the outputted sequence name in the fasta and fastq file. 